### PR TITLE
Template for automatically creating TOC

### DIFF
--- a/workflow-templates/auto-toc.properties.json
+++ b/workflow-templates/auto-toc.properties.json
@@ -1,0 +1,5 @@
+{
+    "name": "Automatically Generate TOC For a README",
+    "description": "Auto TOC workflow template.",
+    "iconName": "example-icon"
+}

--- a/workflow-templates/auto-toc.yaml
+++ b/workflow-templates/auto-toc.yaml
@@ -1,0 +1,13 @@
+name: Generate TOC on README Automatically
+on: 
+ workflow_dispatch:
+ push:
+   branches: master
+   paths: README.md
+
+jobs:
+  generateTOC:
+    name: TOC Generator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: technote-space/toc-generator@v2


### PR DESCRIPTION
This doesn't get globally applied you can choose to add it, via the repo level.  I will not add it everywhere and will find repos that have really dense READMEs that might need a TOC and make a PR with this template